### PR TITLE
Migrate from master and slave phrasing

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -41,8 +41,8 @@ call(['git', 'add', 'heartbeat/common/static/built/main-built.js'])
 call(['git', 'add', 'heartbeat/common/static/built/application.css'])
 call(['git', 'commit', '-m', '"Generated commit, built js and css"'])
 
-call(['git', 'push', 'origin', 'master'])
+call(['git', 'push', 'origin', 'main'])
 print "Pushing to heroku.."
-#call(['cd ' + PROJECT_DIR + '; git push heroku master'])
+#call(['cd ' + PROJECT_DIR + '; git push heroku main'])
 #call(['cd ' + PROJECT_DIR + '; heroku run ./manage.py migrate'])
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.